### PR TITLE
Use new LARA PluginAPI for registering Glossary plugin.

### DIFF
--- a/packages/glossary-plugin/README.md
+++ b/packages/glossary-plugin/README.md
@@ -27,9 +27,9 @@ You *do not* need to build to deploy the code, that is automatic.  See more info
 Production releases to S3 are based on the contents of the /dist folder and are built automatically by Travis
 for each branch pushed to GitHub and each merge into production.
 
-Merges into production are deployed to http://glossary.concord.org.
+Merges into production are deployed to http://glossary-plugin.concord.org.
 
-Other branches are deployed to http://glossary.concord.org/branch/<name>.
+Other branches are deployed to http://glossary-plugin.concord.org/branch/<name>.
 
 You can view the status of all the branch deploys [here](https://travis-ci.org/concord-consortium/collaborative-learning/branches).
 

--- a/packages/glossary-plugin/src/plugin.tsx
+++ b/packages/glossary-plugin/src/plugin.tsx
@@ -4,13 +4,23 @@ import GlossaryPopup from "./components/glossary-popup";
 
 interface IExternalScriptContext {
   div: any;
+  authoredState: any;
 }
-
+interface IWordDefintion {
+  word: string;
+  definition: string;
+}
 const PluginAPI = (window as any).LARA;
 
 export class GlossaryPlugin {
-  constructor(authoredState: any, context: IExternalScriptContext) {
+  private definitions: IWordDefintion[];
+  constructor(label: string, context: IExternalScriptContext) {
     const container = document.createElement("div");
+    const authoredState = context.authoredState ? JSON.parse(context.authoredState) : {};
+    this.definitions = authoredState.definitions ? authoredState.definitions : [{
+      word: "eardrum",
+      definition: "An eardrum is a membrane, or thin piece of skin, stretched tight like a drum."
+    }];
     ReactDOM.render(
       <GlossaryPopup
         word="eardrum"
@@ -20,11 +30,40 @@ export class GlossaryPlugin {
       />,
       container
     );
-    PluginAPI.openPopup({
+    PluginAPI.addPopup({
       content: container,
       title: "Glossary",
       resizable: false
     });
+    this.decorate();
+  }
+
+  private decorate() {
+    const words = this.definitions.map( (entry) => entry.word);
+    const replace = "<span style='text-decoration: underline;'>$1</span>";
+    const wordClass = "cc-glossary-word";
+    const listener = {
+      type: "click",
+      listener: (evt: any) => {
+        const container = document.createElement("div");
+        // TODO: figure out what word we clicked …
+        ReactDOM.render(
+          <GlossaryPopup
+            word="eardrum"
+            definition="An eardrum is a membrane, or thin piece of skin, stretched tight like a drum."
+            askForUserDefinition={true}
+            onUserDefinitionsUpdate={this.saveUserState}
+          />,
+          container
+        );
+        PluginAPI.addPopup({
+          content: container,
+          title: "Glossary",
+          resizable: false
+        });
+      }
+    };
+    PluginAPI.decorateContent(words, replace, wordClass, [listener]);
   }
 
   private saveUserState = (userDefinitions: string[]) => {
@@ -33,9 +72,10 @@ export class GlossaryPlugin {
     };
     PluginAPI.saveUserState(this, JSON.stringify(userState));
   }
+
 }
 
-export const initPlugin = () => {
+const oldInit = () => {
   // TODO soon it will be replaced with window.LARA. For now use legacy ExternalScripts api to register.
   const OldPluginAPI = (window as any).ExternalScripts;
   if (!OldPluginAPI) {
@@ -44,8 +84,19 @@ export const initPlugin = () => {
   }
 
   // tslint:disable-next-line:no-console
-  console.log("LARA Plugin API available, GlossaryPlugin initialization");
+  console.log("OLD External Script Plugin API available, GlossaryPlugin initialization");
   OldPluginAPI.register("glossary", GlossaryPlugin);
+};
+
+export const initPlugin = () => {
+  if (!PluginAPI.registerPlugin) {
+    // tslint:disable-next-line:no-console
+    console.error("LARA Plugin API not available, GlossaryPlugin terminating");
+    return;
+  }
+  // tslint:disable-next-line:no-console
+  console.log("LARA Plugin API available, GlossaryPlugin initialization");
+  PluginAPI.registerPlugin("glossary", GlossaryPlugin);
 };
 
 initPlugin();


### PR DESCRIPTION
This is very much a WIP PR for your review @pjanik 

There is one update README, which fixes a typo in the deployment URL. 

The other changes are to the Glossary plugin, and I was working quickly to try and move to the new Plugin API in LARA.  This WIP branch requires changes that are sitting in `lara-plugin-changes` of LARA repo right now. 

We can remove `const oldInit = () =>{}` method. I left that there for documentation purposes, but its totally useless.

I atse `PluginAPI.decorateContent()` to register words.
Also: Get words and definitions from constructor.

Requires: `lara-plugin-changes` branch from LARA.  Sitting in this [pull request](https://github.com/concord-consortium/lara/pull/325)

