### PR TITLE
Provide a real plugin implementation

### DIFF
--- a/packages/glossary-plugin/src/plugin.scss
+++ b/packages/glossary-plugin/src/plugin.scss
@@ -1,0 +1,4 @@
+.ccGlossaryWord {
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/packages/glossary-plugin/src/plugin.test.ts
+++ b/packages/glossary-plugin/src/plugin.test.ts
@@ -3,15 +3,15 @@ import { initPlugin, GlossaryPlugin } from "./plugin";
 describe("LARA plugin", () => {
   // Mock LARA API.
   const LARA = {
-    register: jest.fn()
+    registerPlugin: jest.fn()
   };
 
   beforeEach(() => {
-    (window as any).ExternalScripts = LARA;
+    (window as any).LARA = LARA;
   });
 
   it("loads without crashing and calls LARA.register", () => {
     initPlugin();
-    expect(LARA.register).toBeCalledWith("glossary", GlossaryPlugin);
+    expect(LARA.registerPlugin).toBeCalledWith("glossary", GlossaryPlugin);
   });
 });

--- a/packages/glossary-plugin/src/plugin.tsx
+++ b/packages/glossary-plugin/src/plugin.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import GlossaryPopup from "./components/glossary-popup";
 
+import * as css from "./plugin.scss";
+
 interface IExternalScriptContext {
   div: any;
   authoredState: any;
@@ -10,60 +12,62 @@ interface IWordDefintion {
   word: string;
   definition: string;
 }
-const PluginAPI = (window as any).LARA;
+
+let PluginAPI: any;
 
 export class GlossaryPlugin {
+  private askForUserDefinition: boolean;
   private definitions: IWordDefintion[];
-  constructor(label: string, context: IExternalScriptContext) {
-    const container = document.createElement("div");
+  private definitionsByWord: { [word: string]: IWordDefintion };
+
+  constructor(context: IExternalScriptContext) {
     const authoredState = context.authoredState ? JSON.parse(context.authoredState) : {};
-    this.definitions = authoredState.definitions ? authoredState.definitions : [{
-      word: "eardrum",
-      definition: "An eardrum is a membrane, or thin piece of skin, stretched tight like a drum."
-    }];
+    this.askForUserDefinition = authoredState.askForUserDefinition || false;
+    this.definitions = authoredState.definitions || [];
+    this.definitionsByWord = {};
+    this.definitions.forEach(entry => {
+      this.definitionsByWord[entry.word] = entry;
+    });
+    if (this.definitions.length > 0) {
+      this.decorate();
+    }
+  }
+
+  private decorate() {
+    const words = this.definitions.map(entry => entry.word);
+    const replace = `<span class=${css.ccGlossaryWord}>$1</span>`;
+    const listener = {
+      type: "click",
+      listener: this.wordClicked
+    };
+    PluginAPI.decorateContent(words, replace, css.ccGlossaryWord, [listener]);
+  }
+
+  private wordClicked = (evt: Event) => {
+    const wordElement = evt.srcElement;
+    const word = wordElement && wordElement.textContent || "";
+    if (!this.definitionsByWord[word]) {
+      // Ignore, nothing to do.
+      return;
+    }
+
+    const container = document.createElement("div");
     ReactDOM.render(
       <GlossaryPopup
-        word="eardrum"
-        definition="An eardrum is a membrane, or thin piece of skin, stretched tight like a drum."
-        askForUserDefinition={true}
+        word={word}
+        definition={this.definitionsByWord[word].definition}
+        askForUserDefinition={this.askForUserDefinition}
         onUserDefinitionsUpdate={this.saveUserState}
       />,
       container
     );
+
     PluginAPI.addPopup({
       content: container,
       title: "Glossary",
-      resizable: false
+      resizable: false,
+      position: { my: "left top+10", at: "left bottom", of: wordElement, collision: "flip" }
     });
-    this.decorate();
-  }
-
-  private decorate() {
-    const words = this.definitions.map( (entry) => entry.word);
-    const replace = "<span style='text-decoration: underline;'>$1</span>";
-    const wordClass = "cc-glossary-word";
-    const listener = {
-      type: "click",
-      listener: (evt: any) => {
-        const container = document.createElement("div");
-        // TODO: figure out what word we clicked …
-        ReactDOM.render(
-          <GlossaryPopup
-            word="eardrum"
-            definition="An eardrum is a membrane, or thin piece of skin, stretched tight like a drum."
-            askForUserDefinition={true}
-            onUserDefinitionsUpdate={this.saveUserState}
-          />,
-          container
-        );
-        PluginAPI.addPopup({
-          content: container,
-          title: "Glossary",
-          resizable: false
-        });
-      }
-    };
-    PluginAPI.decorateContent(words, replace, wordClass, [listener]);
   }
 
   private saveUserState = (userDefinitions: string[]) => {
@@ -72,26 +76,13 @@ export class GlossaryPlugin {
     };
     PluginAPI.saveUserState(this, JSON.stringify(userState));
   }
-
 }
 
-const oldInit = () => {
-  // TODO soon it will be replaced with window.LARA. For now use legacy ExternalScripts api to register.
-  const OldPluginAPI = (window as any).ExternalScripts;
-  if (!OldPluginAPI) {
-    // LARA Plugin API not available. Nothing to do.
-    return;
-  }
-
-  // tslint:disable-next-line:no-console
-  console.log("OLD External Script Plugin API available, GlossaryPlugin initialization");
-  OldPluginAPI.register("glossary", GlossaryPlugin);
-};
-
 export const initPlugin = () => {
-  if (!PluginAPI.registerPlugin) {
+  PluginAPI = (window as any).LARA;
+  if (!PluginAPI || !PluginAPI.registerPlugin) {
     // tslint:disable-next-line:no-console
-    console.error("LARA Plugin API not available, GlossaryPlugin terminating");
+    console.warn("LARA Plugin API not available, GlossaryPlugin terminating");
     return;
   }
   // tslint:disable-next-line:no-console

--- a/packages/text-decorator/package.json
+++ b/packages/text-decorator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/text-decorator",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Part of Concord Consortium's text-plugins which can be used to apply <span> tags and classes to text",
   "keywords": [],
   "main": "dist/text-decorator.umd.js",


### PR DESCRIPTION
Depends on these LARA changes: https://github.com/concord-consortium/lara/pull/326

Updates API, and pretty much implements basic functionality. `wordClass` argument was used incorrectly before. We need to create an element with this class first using `replace` string. I don't really like it, but I don't think we have time to tweak text-decorator now. And it wouldn't be easy to improve.