### PR TITLE
Add sidebar UI + miscellaneous features and updates

### DIFF
--- a/packages/glossary-plugin/src/components/definition.tsx
+++ b/packages/glossary-plugin/src/components/definition.tsx
@@ -2,22 +2,22 @@ import * as React from "react";
 import * as css from "./definition.scss";
 import * as icons from "./icons.scss";
 
-interface IDefinitionProps {
+interface IProps {
   definition: string;
-  userDefinitions: string[] | undefined;
+  userDefinitions?: string[];
   imageUrl?: string;
   videoUrl?: string;
   imageCaption?: string;
   videoCaption?: string;
 }
 
-interface IDefinitionState {
+interface IState {
   imageVisible: boolean;
   videoVisible: boolean;
 }
 
-export default class Definition extends React.Component<IDefinitionProps, IDefinitionState> {
-  public state: IDefinitionState = {
+export default class Definition extends React.Component<IProps, IState> {
+  public state: IState = {
     imageVisible: false,
     videoVisible: false
   };

--- a/packages/glossary-plugin/src/components/definition.tsx
+++ b/packages/glossary-plugin/src/components/definition.tsx
@@ -4,7 +4,7 @@ import * as icons from "./icons.scss";
 
 interface IDefinitionProps {
   definition: string;
-  userDefinitions: string[];
+  userDefinitions: string[] | undefined;
   imageUrl?: string;
   videoUrl?: string;
   imageCaption?: string;
@@ -54,7 +54,7 @@ export default class Definition extends React.Component<IDefinitionProps, IDefin
         }
         {
           // If user already provided some answer, display them below.
-          userDefinitions.length > 0 &&
+          userDefinitions && userDefinitions.length > 0 &&
           <div className={css.userDefinitions}>
             <hr/>
             <div>

--- a/packages/glossary-plugin/src/components/glossary-popup.tsx
+++ b/packages/glossary-plugin/src/components/glossary-popup.tsx
@@ -33,20 +33,21 @@ export default class GlossaryPopup extends React.Component<IGlossaryPopupProps, 
   }
 
   private renderDefinition() {
-    const { definition, userDefinitions, imageUrl, videoUrl, imageCaption, videoCaption } = this.props;
+    const { askForUserDefinition, definition, userDefinitions, imageUrl,
+      videoUrl, imageCaption, videoCaption } = this.props;
     const anyUserDef = userDefinitions && userDefinitions.length > 0;
     return (
       <div>
         <Definition
           definition={definition}
-          userDefinitions={userDefinitions}
+          userDefinitions={askForUserDefinition ? userDefinitions : []}
           imageUrl={imageUrl}
           videoUrl={videoUrl}
           imageCaption={imageCaption}
           videoCaption={videoCaption}
         />
         {
-          anyUserDef &&
+          askForUserDefinition && anyUserDef &&
           <div className={css.buttons}>
             <div className={css.button} data-cy="revise" onClick={this.handleRevise}>
               Revise my definition

--- a/packages/glossary-plugin/src/components/glossary-popup.tsx
+++ b/packages/glossary-plugin/src/components/glossary-popup.tsx
@@ -5,7 +5,7 @@ import * as css from "./glossary-popup.scss";
 interface IGlossaryPopupProps {
   word: string;
   definition: string;
-  userDefinitions: string[];
+  userDefinitions: string[] | undefined;
   askForUserDefinition?: boolean;
   onUserDefinitionsUpdate?: (userDefinitions: string) => void;
   imageUrl?: string;
@@ -22,7 +22,9 @@ interface IGlossaryPopupState {
 export default class GlossaryPopup extends React.Component<IGlossaryPopupProps, IGlossaryPopupState> {
   public state: IGlossaryPopupState = {
     currentUserDefinition: "",
-    questionVisible: this.props.askForUserDefinition && this.props.userDefinitions.length === 0 || false,
+    questionVisible:
+      this.props.askForUserDefinition && (!this.props.userDefinitions || this.props.userDefinitions.length === 0)
+      || false,
   };
 
   public render() {
@@ -32,7 +34,7 @@ export default class GlossaryPopup extends React.Component<IGlossaryPopupProps, 
 
   private renderDefinition() {
     const { definition, userDefinitions, imageUrl, videoUrl, imageCaption, videoCaption } = this.props;
-    const anyUserDef = userDefinitions.length > 0;
+    const anyUserDef = userDefinitions && userDefinitions.length > 0;
     return (
       <div>
         <Definition
@@ -58,7 +60,7 @@ export default class GlossaryPopup extends React.Component<IGlossaryPopupProps, 
   private renderQuestion() {
     const { word, userDefinitions } = this.props;
     const { currentUserDefinition } = this.state;
-    const anyUserDef = userDefinitions.length > 0;
+    const anyUserDef = userDefinitions && userDefinitions.length > 0;
     return (
       <div>
         What do you think "{word}" means?
@@ -70,7 +72,7 @@ export default class GlossaryPopup extends React.Component<IGlossaryPopupProps, 
         />
         {
           // If user already provided some answer, display them below.
-          anyUserDef &&
+          userDefinitions && userDefinitions.length > 0 &&
           <div className={css.userDefinitions}>
             <div>
               <b>My previous definition:</b>

--- a/packages/glossary-plugin/src/components/glossary-popup.tsx
+++ b/packages/glossary-plugin/src/components/glossary-popup.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import Definition from "./definition";
 import * as css from "./glossary-popup.scss";
 
-interface IGlossaryPopupProps {
+interface IProps {
   word: string;
   definition: string;
-  userDefinitions: string[] | undefined;
+  userDefinitions?: string[];
   askForUserDefinition?: boolean;
   onUserDefinitionsUpdate?: (userDefinitions: string) => void;
   imageUrl?: string;
@@ -14,13 +14,13 @@ interface IGlossaryPopupProps {
   videoCaption?: string;
 }
 
-interface IGlossaryPopupState {
+interface IState {
   currentUserDefinition: string;
   questionVisible: boolean;
 }
 
-export default class GlossaryPopup extends React.Component<IGlossaryPopupProps, IGlossaryPopupState> {
-  public state: IGlossaryPopupState = {
+export default class GlossaryPopup extends React.Component<IProps, IState> {
+  public state: IState = {
     currentUserDefinition: "",
     questionVisible:
       this.props.askForUserDefinition && (!this.props.userDefinitions || this.props.userDefinitions.length === 0)

--- a/packages/glossary-plugin/src/components/glossary-sidebar.scss
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.scss
@@ -1,0 +1,12 @@
+.entry {
+  margin-bottom: 30px;
+}
+
+.word {
+  font-weight: bold;
+  margin-bottom: 15px;
+}
+
+.definition {
+  margin-left: 20px;
+}

--- a/packages/glossary-plugin/src/components/glossary-sidebar.scss
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.scss
@@ -10,3 +10,29 @@
 .definition {
   margin-left: 20px;
 }
+
+.toggles {
+  text-align: center;
+}
+
+.toggle {
+  display: inline-block;
+  background: #bbb;
+  padding: 7px;
+  border: 3px solid #ddd;
+  color: #fff;
+  cursor: pointer;
+
+  &:first-child {
+    border-top-left-radius: 8px;
+    border-bottom-left-radius: 8px;
+  }
+  &:last-child {
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+  }
+}
+
+.activeToggle {
+  background: #666;
+}

--- a/packages/glossary-plugin/src/components/glossary-sidebar.tsx
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.tsx
@@ -9,16 +9,56 @@ interface IGlossarySidebarProps {
   learnerDefinitions: ILearnerDefinitions;
 }
 
-// interface IGlossarySidebarState {
-// }
+enum Filter {
+  AllWords,
+  WithUserDefinitionOnly
+}
 
-export default class GlossarySidebar extends React.Component<IGlossarySidebarProps, {}> {
+interface IGlossarySidebarState {
+  filter: Filter;
+}
+
+const nonEmptyHash = (hash: any) => {
+  return Object.keys(hash).length > 0;
+};
+
+export default class GlossarySidebar extends React.Component<IGlossarySidebarProps, IGlossarySidebarState> {
+  public state: IGlossarySidebarState = {
+    // Show words that have user definition by default. Note that this filter will be ignored if user hasn't defined
+    // anything yet.
+    filter: Filter.WithUserDefinitionOnly
+  };
+
   public render() {
     const { definitions, learnerDefinitions } = this.props;
+    const { filter } = this.state;
+    const wordsIHaveDefinedClass = css.toggle
+      + (filter === Filter.WithUserDefinitionOnly ? " " + css.activeToggle : "");
+    const allWordsClass = css.toggle + (filter === Filter.AllWords ? " " + css.activeToggle : "");
     return (
       <div>
         {
-          definitions.map((entry: IWordDefinition) =>
+          // Show toggles only if there's anything to toggle between.
+          nonEmptyHash(learnerDefinitions) &&
+          <div>
+            <div className={css.toggles}>
+              <div className={wordsIHaveDefinedClass} onClick={this.ownWordsClicked}>Words I Have Defined</div>
+              <div className={allWordsClass} onClick={this.allWordsClicked}>All Words</div>
+            </div>
+            <hr/>
+          </div>
+        }
+        {
+          definitions
+            .filter((entry: IWordDefinition) => {
+              if (nonEmptyHash(learnerDefinitions) && filter === Filter.WithUserDefinitionOnly) {
+                // Apply this filter only if result is going to include anything.
+                return learnerDefinitions[entry.word] && learnerDefinitions[entry.word].length > 0;
+              }
+              // filter === Filter.AllWords
+              return true;
+            })
+            .map((entry: IWordDefinition) =>
             <div className={css.entry}>
               <div className={css.word}>{ entry.word }</div>
               <div className={css.definition}>
@@ -36,5 +76,13 @@ export default class GlossarySidebar extends React.Component<IGlossarySidebarPro
         }
       </div>
     );
+  }
+
+  private ownWordsClicked = () => {
+    this.setState({ filter: Filter.WithUserDefinitionOnly });
+  }
+
+  private allWordsClicked = () => {
+    this.setState({ filter: Filter.AllWords });
   }
 }

--- a/packages/glossary-plugin/src/components/glossary-sidebar.tsx
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.tsx
@@ -4,26 +4,26 @@ import { IWordDefinition, ILearnerDefinitions } from "./types";
 
 import * as css from "./glossary-sidebar.scss";
 
-interface IGlossarySidebarProps {
-  definitions: IWordDefinition[];
-  learnerDefinitions: ILearnerDefinitions;
-}
-
 enum Filter {
   AllWords,
   WithUserDefinitionOnly
-}
-
-interface IGlossarySidebarState {
-  filter: Filter;
 }
 
 const nonEmptyHash = (hash: any) => {
   return Object.keys(hash).length > 0;
 };
 
-export default class GlossarySidebar extends React.Component<IGlossarySidebarProps, IGlossarySidebarState> {
-  public state: IGlossarySidebarState = {
+interface IProps {
+  definitions: IWordDefinition[];
+  learnerDefinitions: ILearnerDefinitions;
+}
+
+interface IState {
+  filter: Filter;
+}
+
+export default class GlossarySidebar extends React.Component<IProps, IState> {
+  public state: IState = {
     // Show words that have user definition by default. Note that this filter will be ignored if user hasn't defined
     // anything yet.
     filter: Filter.WithUserDefinitionOnly

--- a/packages/glossary-plugin/src/components/glossary-sidebar.tsx
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.tsx
@@ -59,8 +59,8 @@ export default class GlossarySidebar extends React.Component<IGlossarySidebarPro
               return true;
             })
             .map((entry: IWordDefinition) =>
-            <div className={css.entry}>
-              <div className={css.word}>{ entry.word }</div>
+            <div key={entry.word} className={css.entry}>
+              <div className={css.word}>{entry.word}</div>
               <div className={css.definition}>
                 <Definition
                   definition={entry.definition}

--- a/packages/glossary-plugin/src/components/glossary-sidebar.tsx
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import Definition from "./definition";
+import { IWordDefinition, ILearnerDefinitions } from "./types";
+
+import * as css from "./glossary-sidebar.scss";
+
+interface IGlossarySidebarProps {
+  definitions: IWordDefinition[];
+  learnerDefinitions: ILearnerDefinitions;
+}
+
+// interface IGlossarySidebarState {
+// }
+
+export default class GlossarySidebar extends React.Component<IGlossarySidebarProps, {}> {
+  public render() {
+    const { definitions, learnerDefinitions } = this.props;
+    return (
+      <div>
+        {
+          definitions.map((entry: IWordDefinition) =>
+            <div className={css.entry}>
+              <div className={css.word}>{ entry.word }</div>
+              <div className={css.definition}>
+                <Definition
+                  definition={entry.definition}
+                  userDefinitions={learnerDefinitions[entry.word]}
+                  imageUrl={entry.image}
+                  videoUrl={entry.video}
+                  imageCaption={entry.imageCaption}
+                  videoCaption={entry.videoCaption}
+                />
+              </div>
+            </div>
+          )
+        }
+      </div>
+    );
+  }
+}

--- a/packages/glossary-plugin/src/components/plugin-app.scss
+++ b/packages/glossary-plugin/src/components/plugin-app.scss
@@ -2,3 +2,8 @@
   text-decoration: underline;
   cursor: pointer;
 }
+
+.sidebarIcon {
+  color: white;
+  font-size: 35px;
+}

--- a/packages/glossary-plugin/src/components/plugin-app.test.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.test.tsx
@@ -12,7 +12,7 @@ describe("PluginApp component", () => {
     }
   ];
   const initialLearnerState = { definitions: {} };
-  const plugin = "it should be LARA plugin instance, but PluginAPP doesn't care";
+  const pluginId = "123";
 
   it("calls decorateContent on load", () => {
     const MockAPI = {
@@ -21,7 +21,7 @@ describe("PluginApp component", () => {
     shallow(
       <PluginApp
         PluginAPI={MockAPI}
-        plugin={plugin}
+        pluginId={pluginId}
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
@@ -53,7 +53,7 @@ describe("PluginApp component", () => {
     const wrapper = shallow(
       <PluginApp
         PluginAPI={MockAPI}
-        plugin={plugin}
+        pluginId={pluginId}
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
@@ -74,16 +74,16 @@ describe("PluginApp component", () => {
     expect(wrapper.find(GlossaryPopup).length).toEqual(0);
   });
 
-  it("calls saveLearnerState when learner state is updated", () => {
+  it("calls saveLearnerPluginState when learner state is updated", () => {
     const MockAPI = {
       decorateContent: jest.fn(),
-      saveLearnerState: jest.fn(),
+      saveLearnerPluginState: jest.fn(),
     };
 
     const wrapper = shallow(
       <PluginApp
         PluginAPI={MockAPI}
-        plugin={plugin}
+        pluginId={pluginId}
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={true}
@@ -94,15 +94,15 @@ describe("PluginApp component", () => {
     const word = "test";
     const definition1 = "user definition 1";
     (component as PluginApp).learnerDefinitionUpdated(word, definition1);
-    expect(MockAPI.saveLearnerState).toHaveBeenCalledTimes(1);
-    expect(MockAPI.saveLearnerState).toHaveBeenCalledWith(plugin, JSON.stringify({
+    expect(MockAPI.saveLearnerPluginState).toHaveBeenCalledTimes(1);
+    expect(MockAPI.saveLearnerPluginState).toHaveBeenCalledWith(pluginId, JSON.stringify({
       definitions: {[word]: [ definition1 ]}
     }));
 
     const definition2 = "user definition 2";
     (component as PluginApp).learnerDefinitionUpdated(word, definition2);
-    expect(MockAPI.saveLearnerState).toHaveBeenCalledTimes(2);
-    expect(MockAPI.saveLearnerState).toHaveBeenCalledWith(plugin, JSON.stringify({
+    expect(MockAPI.saveLearnerPluginState).toHaveBeenCalledTimes(2);
+    expect(MockAPI.saveLearnerPluginState).toHaveBeenCalledWith(pluginId, JSON.stringify({
       definitions: {[word]: [ definition1, definition2 ]}
     }));
   });

--- a/packages/glossary-plugin/src/components/plugin-app.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.tsx
@@ -17,7 +17,12 @@ interface IOpenPopupDesc {
   popupController: any; // provided by LARA
 }
 
-interface IPluginAppProps {
+interface ISidebarController {
+  open: () => void;
+  close: () => void;
+}
+
+interface IProps {
   PluginAPI: any;
   pluginId: string; // plugin instance ID that needs to be passed to LARA.saveLearnerState
   definitions: IWordDefinition[];
@@ -25,18 +30,13 @@ interface IPluginAppProps {
   askForUserDefinition: boolean;
 }
 
-interface IPluginAppState {
+interface IState {
   openPopups: IOpenPopupDesc[];
   learnerState: ILearnerState;
 }
 
-interface ISidebarController {
-  open: () => void;
-  close: () => void;
-}
-
-export default class PluginApp extends React.Component<IPluginAppProps, IPluginAppState> {
-  public state: IPluginAppState = {
+export default class PluginApp extends React.Component<IProps, IState> {
+  public state: IState = {
     openPopups: [],
     learnerState: this.props.initialLearnerState
   };

--- a/packages/glossary-plugin/src/components/plugin-app.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.tsx
@@ -1,8 +1,11 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import GlossaryPopup from "./glossary-popup";
+import GlossarySidebar from "./glossary-sidebar";
+import { IWordDefinition, ILearnerDefinitions } from "./types";
 
 import * as css from "./plugin-app.scss";
+import * as icons from "./icons.scss";
 
 interface IPluginProps {
   PluginAPI: any;
@@ -12,17 +15,8 @@ interface IPluginProps {
   askForUserDefinition: boolean;
 }
 
-interface IWordDefinition {
-  word: string;
-  definition: string;
-  image?: string;
-  video?: string;
-  imageCaption?: string;
-  videoCaption?: string;
-}
-
 interface ILearnerState {
-  definitions: { [word: string]: string[] };
+  definitions: ILearnerDefinitions;
 }
 
 interface IPluginState {
@@ -42,6 +36,8 @@ export default class PluginApp extends React.Component<IPluginProps, IPluginStat
     learnerState: this.props.initialLearnerState
   };
   private definitionsByWord: { [word: string]: IWordDefinition };
+  private sidebarContainer: HTMLElement = document.createElement("div");
+  private sidebarIconContainer: HTMLElement = document.createElement("div");
 
   public componentDidMount() {
     const { definitions } = this.props;
@@ -51,32 +47,57 @@ export default class PluginApp extends React.Component<IPluginProps, IPluginStat
     });
     if (definitions.length > 0) {
       this.decorate();
+      this.setupSidebar();
     }
   }
 
   public render() {
-    const { askForUserDefinition } = this.props;
+    const { askForUserDefinition, definitions } = this.props;
     const { openPopups, learnerState } = this.state;
 
-    // `openPopups.length === 0 ? null` seems not necessary but it fixes the tests.
-    // Apparently, Enzyme or React get confused when [] is returned.
-    return openPopups.length === 0 ? null : openPopups.map((desc: IOpenPopupDesc) => {
-      const { word, container } = desc;
-      return ReactDOM.createPortal(
-        <GlossaryPopup
-          word={word}
-          definition={this.definitionsByWord[word].definition}
-          imageUrl={this.definitionsByWord[word].image}
-          videoUrl={this.definitionsByWord[word].video}
-          imageCaption={this.definitionsByWord[word].imageCaption}
-          videoCaption={this.definitionsByWord[word].videoCaption}
-          userDefinitions={learnerState.definitions[word] || []}
-          askForUserDefinition={askForUserDefinition}
-          onUserDefinitionsUpdate={this.learnerDefinitionUpdated.bind(this, word)}
-        />,
-        container
-      );
-    });
+    // Note that returned div will be empty in fact. We render only into React Portals.
+    // It's possible to return array instead, but it seems to cause some cryptic errors in tests.
+    return (
+      <div>
+        {
+          // Render sidebar into portal.
+          ReactDOM.createPortal(
+            <GlossarySidebar
+              definitions={definitions}
+              learnerDefinitions={learnerState.definitions}
+            />,
+            this.sidebarContainer
+          )
+        }
+        {
+          // Render sidebar icon into portal.
+          ReactDOM.createPortal(
+            <span className={css.sidebarIcon + " " + icons.iconBook}/>,
+            this.sidebarIconContainer
+          )
+        }
+        {
+          // Render popups into portals.
+          openPopups.length === 0 ? null : openPopups.map((desc: IOpenPopupDesc) => {
+            const {word, container} = desc;
+            return ReactDOM.createPortal(
+              <GlossaryPopup
+                word={word}
+                definition={this.definitionsByWord[word].definition}
+                imageUrl={this.definitionsByWord[word].image}
+                videoUrl={this.definitionsByWord[word].video}
+                imageCaption={this.definitionsByWord[word].imageCaption}
+                videoCaption={this.definitionsByWord[word].videoCaption}
+                userDefinitions={learnerState.definitions[word]}
+                askForUserDefinition={askForUserDefinition}
+                onUserDefinitionsUpdate={this.learnerDefinitionUpdated.bind(this, word)}
+              />,
+              container
+            );
+          })
+        }
+      </div>
+    );
   }
 
   public learnerDefinitionUpdated = (word: string, newDefinition: string) => {
@@ -103,6 +124,30 @@ export default class PluginApp extends React.Component<IPluginProps, IPluginStat
     PluginAPI.decorateContent(words, replace, css.ccGlossaryWord, [listener]);
   }
 
+  private setupSidebar() {
+    const { PluginAPI } = this.props;
+    if (!PluginAPI.addSidebar) {
+      return;
+    }
+    PluginAPI.addSidebar({
+      title: "Glossary",
+      handleColor: "#777",
+      width: 450,
+      height: 500,
+      icon: this.sidebarIconContainer,
+      content: this.sidebarContainer,
+      onOpen: this.sidebarOpened
+    });
+  }
+
+  private sidebarOpened = () => {
+    // Close all the popups.
+    const { openPopups } = this.state;
+    openPopups.forEach((desc: IOpenPopupDesc) => {
+      desc.popupController.close();
+    });
+  }
+
   private wordClicked = (evt: Event) => {
     const { PluginAPI } = this.props;
     const wordElement = evt.srcElement;
@@ -118,13 +163,13 @@ export default class PluginApp extends React.Component<IPluginProps, IPluginStat
       title: "Glossary",
       resizable: false,
       position: { my: "left top+10", at: "left bottom", of: wordElement, collision: "flip" },
-      onClose: this.popupClosedByUser.bind(this, container)
+      onClose: this.popupClosed.bind(this, container)
     });
     const newOpenPopups = openPopups.concat({ word, container, popupController });
     this.setState({ openPopups: newOpenPopups });
   }
 
-  private popupClosedByUser(container: HTMLElement) {
+  private popupClosed(container: HTMLElement) {
     // Keep state in sync. Popup can be closed using X sign in LARA. We don't control that.
     // Remove popup from list of opened popups. It will also ensure that Popup component will unmount correctly.
     const { openPopups } = this.state;

--- a/packages/glossary-plugin/src/components/plugin-app.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.tsx
@@ -43,7 +43,7 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
   private definitionsByWord: { [word: string]: IWordDefinition };
   private sidebarContainer: HTMLElement = document.createElement("div");
   private sidebarIconContainer: HTMLElement = document.createElement("div");
-  private sidebarController: ISidebarController = this.addSidebar();
+  private sidebarController: ISidebarController | null = this.addSidebar();
 
   public componentDidMount() {
     const { definitions } = this.props;
@@ -133,8 +133,12 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
     PluginAPI.decorateContent(words, replace, css.ccGlossaryWord, [listener]);
   }
 
-  private addSidebar(): ISidebarController {
+  private addSidebar(): ISidebarController | null {
     const { PluginAPI } = this.props;
+    if (!PluginAPI.addSidebar) {
+      // Most likely use case - test environment. So it's easier to mock LARA API.
+      return null;
+    }
     return PluginAPI.addSidebar({
       handle: "Glossary",
       titleBar: "Glossary",
@@ -175,8 +179,10 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
     });
     const newOpenPopups = openPopups.concat({ word, container, popupController });
     this.setState({ openPopups: newOpenPopups });
-    // Finally, close sidebar in case it's open.
-    this.sidebarController.close();
+    // Finally, close sidebar in case it's available and open.
+    if (this.sidebarController) {
+      this.sidebarController.close();
+    }
   }
 
   private popupClosed(container: HTMLElement) {

--- a/packages/glossary-plugin/src/components/plugin-app.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.tsx
@@ -7,21 +7,8 @@ import { IWordDefinition, ILearnerDefinitions } from "./types";
 import * as css from "./plugin-app.scss";
 import * as icons from "./icons.scss";
 
-interface IPluginProps {
-  PluginAPI: any;
-  plugin: any; // plugin instance that needs to be passed to LARA.saveLearnerState
-  definitions: IWordDefinition[];
-  initialLearnerState: ILearnerState;
-  askForUserDefinition: boolean;
-}
-
 interface ILearnerState {
   definitions: ILearnerDefinitions;
-}
-
-interface IPluginState {
-  openPopups: IOpenPopupDesc[];
-  learnerState: ILearnerState;
 }
 
 interface IOpenPopupDesc {
@@ -30,8 +17,21 @@ interface IOpenPopupDesc {
   popupController: any; // provided by LARA
 }
 
-export default class PluginApp extends React.Component<IPluginProps, IPluginState> {
-  public state: IPluginState = {
+interface IPluginAppProps {
+  PluginAPI: any;
+  pluginId: string; // plugin instance ID that needs to be passed to LARA.saveLearnerState
+  definitions: IWordDefinition[];
+  initialLearnerState: ILearnerState;
+  askForUserDefinition: boolean;
+}
+
+interface IPluginAppState {
+  openPopups: IOpenPopupDesc[];
+  learnerState: ILearnerState;
+}
+
+export default class PluginApp extends React.Component<IPluginAppProps, IPluginAppState> {
+  public state: IPluginAppState = {
     openPopups: [],
     learnerState: this.props.initialLearnerState
   };
@@ -101,7 +101,7 @@ export default class PluginApp extends React.Component<IPluginProps, IPluginStat
   }
 
   public learnerDefinitionUpdated = (word: string, newDefinition: string) => {
-    const { PluginAPI, plugin } = this.props;
+    const { PluginAPI, pluginId } = this.props;
     const { learnerState } = this.state;
     // Make sure that reference is updated, so React can detect changes. ImmutableJS could be helpful.
     const newLearnerState = Object.assign({}, learnerState);
@@ -110,7 +110,7 @@ export default class PluginApp extends React.Component<IPluginProps, IPluginStat
     }
     newLearnerState.definitions[word] = newLearnerState.definitions[word].concat(newDefinition);
     this.setState({ learnerState: newLearnerState });
-    PluginAPI.saveLearnerState(plugin, JSON.stringify(newLearnerState));
+    PluginAPI.saveLearnerState(pluginId, JSON.stringify(newLearnerState));
   }
 
   private decorate() {
@@ -130,7 +130,9 @@ export default class PluginApp extends React.Component<IPluginProps, IPluginStat
       return;
     }
     PluginAPI.addSidebar({
-      title: "Glossary",
+      handle: "Glossary",
+      titleBar: "Glossary",
+      titleBarColor: "#bbb",
       handleColor: "#777",
       width: 450,
       height: 500,

--- a/packages/glossary-plugin/src/components/plugin-app.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.tsx
@@ -115,7 +115,7 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
     }
     newLearnerState.definitions[word] = newLearnerState.definitions[word].concat(newDefinition);
     this.setState({ learnerState: newLearnerState });
-    PluginAPI.saveLearnerState(pluginId, JSON.stringify(newLearnerState));
+    PluginAPI.saveLearnerPluginState(pluginId, JSON.stringify(newLearnerState));
   }
 
   private decorate() {

--- a/packages/glossary-plugin/src/components/plugin-app.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.tsx
@@ -66,10 +66,12 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
       <div>
         {
           // Render sidebar into portal.
+          // Do not render user definitions if askForUserDefinition mode is disabled.
+          // Note that they might be available if previously this mode was enabled.
           ReactDOM.createPortal(
             <GlossarySidebar
               definitions={definitions}
-              learnerDefinitions={learnerState.definitions}
+              learnerDefinitions={askForUserDefinition ? learnerState.definitions : {}}
             />,
             this.sidebarContainer
           )
@@ -83,6 +85,8 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
         }
         {
           // Render popups into portals.
+          // Do not render user definitions if askForUserDefinition mode is disabled.
+          // Note that they might be available if previously this mode was enabled.
           openPopups.length === 0 ? null : openPopups.map((desc: IOpenPopupDesc) => {
             const {word, container} = desc;
             return ReactDOM.createPortal(

--- a/packages/glossary-plugin/src/components/plugin-app.tsx
+++ b/packages/glossary-plugin/src/components/plugin-app.tsx
@@ -30,6 +30,11 @@ interface IPluginAppState {
   learnerState: ILearnerState;
 }
 
+interface ISidebarController {
+  open: () => void;
+  close: () => void;
+}
+
 export default class PluginApp extends React.Component<IPluginAppProps, IPluginAppState> {
   public state: IPluginAppState = {
     openPopups: [],
@@ -38,6 +43,7 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
   private definitionsByWord: { [word: string]: IWordDefinition };
   private sidebarContainer: HTMLElement = document.createElement("div");
   private sidebarIconContainer: HTMLElement = document.createElement("div");
+  private sidebarController: ISidebarController = this.addSidebar();
 
   public componentDidMount() {
     const { definitions } = this.props;
@@ -47,7 +53,6 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
     });
     if (definitions.length > 0) {
       this.decorate();
-      this.setupSidebar();
     }
   }
 
@@ -124,12 +129,9 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
     PluginAPI.decorateContent(words, replace, css.ccGlossaryWord, [listener]);
   }
 
-  private setupSidebar() {
+  private addSidebar(): ISidebarController {
     const { PluginAPI } = this.props;
-    if (!PluginAPI.addSidebar) {
-      return;
-    }
-    PluginAPI.addSidebar({
+    return PluginAPI.addSidebar({
       handle: "Glossary",
       titleBar: "Glossary",
       titleBarColor: "#bbb",
@@ -169,6 +171,8 @@ export default class PluginApp extends React.Component<IPluginAppProps, IPluginA
     });
     const newOpenPopups = openPopups.concat({ word, container, popupController });
     this.setState({ openPopups: newOpenPopups });
+    // Finally, close sidebar in case it's open.
+    this.sidebarController.close();
   }
 
   private popupClosed(container: HTMLElement) {

--- a/packages/glossary-plugin/src/components/types.ts
+++ b/packages/glossary-plugin/src/components/types.ts
@@ -1,0 +1,12 @@
+export interface IWordDefinition {
+  word: string;
+  definition: string;
+  image?: string;
+  video?: string;
+  imageCaption?: string;
+  videoCaption?: string;
+}
+
+export interface ILearnerDefinitions {
+  [word: string]: string[];
+}

--- a/packages/glossary-plugin/src/plugin.test.ts
+++ b/packages/glossary-plugin/src/plugin.test.ts
@@ -19,8 +19,9 @@ describe("LARA plugin initialization", () => {
 describe("GlossaryPlugin", () => {
   it("renders PluginApp component", () => {
     const context = {
-      authoredState: null,
-      learnerState: null,
+      authoredState: "{}",
+      learnerState: "",
+      pluginId: "123",
       div: document.createElement("div")
     };
     document.body.appendChild(context.div);

--- a/packages/glossary-plugin/src/plugin.tsx
+++ b/packages/glossary-plugin/src/plugin.tsx
@@ -4,11 +4,14 @@ import PluginApp from "./components/plugin-app";
 
 interface IExternalScriptContext {
   div: any;
-  authoredState: any;
-  learnerState: any;
+  authoredState: string;
+  learnerState: string;
+  pluginId: string;
 }
 
 let PluginAPI: any;
+
+const fallbackLearnerState = { definitions: {} };
 
 export class GlossaryPlugin {
   public pluginAppComponent: any;
@@ -17,17 +20,23 @@ export class GlossaryPlugin {
     const authoredState = context.authoredState ? JSON.parse(context.authoredState) : {};
     const definitions = authoredState.definitions || [];
     const askForUserDefinition = authoredState.askForUserDefinition || false;
-    let initialLearnerState = context.learnerState;
-    try {
-      initialLearnerState = JSON.parse(context.learnerState);
-    } catch (error) {
-      initialLearnerState = { definitions: {} };
+    let initialLearnerState;
+    if (!context.learnerState) {
+      initialLearnerState = fallbackLearnerState;
+    } else {
+      try {
+        initialLearnerState = JSON.parse(context.learnerState);
+      } catch (error) {
+        // tslint:disable-next-line:no-console
+        console.warn("Unexpected learnerState:", context.learnerState);
+        initialLearnerState = fallbackLearnerState;
+      }
     }
 
     this.pluginAppComponent = ReactDOM.render(
       <PluginApp
         PluginAPI={PluginAPI}
-        plugin={this}
+        pluginId={context.pluginId}
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={askForUserDefinition}


### PR DESCRIPTION
I'm opening just one PR, even though some features are not related to each other. But I hope it's easier that way (instead of 4 PRs). Usually, one change is made in on commit and their names should be pretty descriptive.

The most important things:
 - sidebar UI
 - LARA.saveLearnerState => LARA.saveLearnerPluginState (so we can remove depreciated version in LARA
 - some logic related to popup opening vs sidebar (and vice versa)
 - fixed rendering when we don't ask for student defintions
 - updated logic related to the default filtering mode (so it's as close to Carolyn's expectations as possible)