### PR TITLE
Let authors specify URL pointing to the glossary definition

### DIFF
--- a/packages/glossary-plugin/README.md
+++ b/packages/glossary-plugin/README.md
@@ -24,6 +24,14 @@ Example:
 }
 ```
 
+Note that you can define glossary inline or specify URL to a JSON that contains it:
+
+```json
+{
+  "url": "https://example.concord.org/glossary-definiton.json"
+}
+```
+
 ## LARA Plugin URL:
 
 - `http://glossary-plugin.concord.org/version/<version_number>/plugin.js`

--- a/packages/glossary-plugin/package-lock.json
+++ b/packages/glossary-plugin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@concord-consortium/glossary-plugin",
-	"version": "0.0.1",
+	"version": "1.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -889,7 +889,7 @@
 		},
 		"babel-plugin-istanbul": {
 			"version": "4.1.6",
-			"resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
@@ -5408,7 +5408,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
@@ -5609,6 +5609,16 @@
 			"requires": {
 				"jest-mock": "^23.2.0",
 				"jest-util": "^23.4.0"
+			}
+		},
+		"jest-fetch-mock": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-1.6.6.tgz",
+			"integrity": "sha512-qMorYR8iE0OyOHmroCJVVLuJlRHMcRdrrvYFo1PMY9ErWyCs9ZrL3RGHjkxVgGJSZwKzUlsWgqVFhOK3TMA3eg==",
+			"dev": true,
+			"requires": {
+				"isomorphic-fetch": "^2.2.1",
+				"promise-polyfill": "^7.1.1"
 			}
 		},
 		"jest-get-type": {
@@ -6119,7 +6129,7 @@
 				},
 				"yargs": {
 					"version": "11.1.0",
-					"resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
@@ -8106,6 +8116,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
 			"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+			"dev": true
+		},
+		"promise-polyfill": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
+			"integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
 			"dev": true
 		},
 		"prompts": {
@@ -10986,9 +11002,9 @@
 			}
 		},
 		"whatwg-fetch": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
 			"dev": true
 		},
 		"whatwg-mimetype": {

--- a/packages/glossary-plugin/package.json
+++ b/packages/glossary-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@concord-consortium/glossary-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Glossary LARA plugin",
   "main": "index.js",
   "scripts": {
@@ -60,6 +60,7 @@
     "identity-obj-proxy": "^3.0.0",
     "ignore-styles": "^5.0.1",
     "jest": "^23.6.0",
+    "jest-fetch-mock": "^1.6.6",
     "mini-css-extract-plugin": "^0.4.2",
     "node-sass": "^4.9.3",
     "npm-run-all": "^4.1.3",

--- a/packages/glossary-plugin/src/plugin.tsx
+++ b/packages/glossary-plugin/src/plugin.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import PluginApp from "./components/plugin-app";
+import "whatwg-fetch"; // window.fetch polyfill for older browsers (IE)
 
 interface IExternalScriptContext {
   div: any;
@@ -11,43 +12,74 @@ interface IExternalScriptContext {
 
 let PluginAPI: any;
 
-const fallbackLearnerState = { definitions: {} };
+const getAuthoredState = async (context: IExternalScriptContext) => {
+  if (!context.authoredState) {
+    return {};
+  }
+  let authoredState;
+  try {
+    authoredState = JSON.parse(context.authoredState);
+  } catch (error) {
+    // tslint:disable-next-line:no-console
+    console.warn("Unexpected authoredState:", context.authoredState);
+    return {};
+  }
+  // Authored state can contain all the necessary data already or specify only URL that points to a proper state.
+  if (typeof authoredState.url === "string") {
+    const response = await fetch(authoredState.url);
+    try {
+      const textResponse = await response.text();
+      return JSON.parse(textResponse);
+    } catch (error) {
+      // tslint:disable-next-line:no-console
+      console.warn("Unexpected/malformed authoredState at URL:", authoredState.url);
+      return {};
+    }
+  } else {
+    return authoredState;
+  }
+};
+
+const getLearnerState = (context: IExternalScriptContext) => {
+  const fallbackLearnerState = { definitions: {} };
+  if (!context.learnerState) {
+    return fallbackLearnerState;
+  }
+  try {
+    return JSON.parse(context.learnerState);
+  } catch (error) {
+    // tslint:disable-next-line:no-console
+    console.warn("Unexpected learnerState:", context.learnerState);
+    return fallbackLearnerState;
+  }
+};
 
 export class GlossaryPlugin {
+  public context: IExternalScriptContext;
   public pluginAppComponent: any;
 
   constructor(context: IExternalScriptContext) {
-    let authoredState;
-    if (!context.authoredState) {
-      authoredState = {};
-    } else {
-      try {
-        authoredState = JSON.parse(context.authoredState);
-      } catch (error) {
-        // tslint:disable-next-line:no-console
-        console.warn("Unexpected authoredState:", context.authoredState);
-        authoredState = {};
-      }
-    }
+    this.context = context;
+    // Note renderPluginApp is an async function. Constructor can't be async, as it needs to return immediately.
+    // It also means that component won't be rendered immediately. That's fine.
+    this.renderPluginApp();
+  }
+
+  public renderPluginApp = async () => {
+    const authoredState = await getAuthoredState(this.context);
     const definitions = authoredState.definitions || [];
     const askForUserDefinition = authoredState.askForUserDefinition || false;
-    let initialLearnerState;
-    if (!context.learnerState) {
-      initialLearnerState = fallbackLearnerState;
-    } else {
-      try {
-        initialLearnerState = JSON.parse(context.learnerState);
-      } catch (error) {
-        // tslint:disable-next-line:no-console
-        console.warn("Unexpected learnerState:", context.learnerState);
-        initialLearnerState = fallbackLearnerState;
-      }
+    const initialLearnerState = getLearnerState(this.context);
+
+    if (this.pluginAppComponent) {
+      ReactDOM.unmountComponentAtNode(this.context.div);
+      this.pluginAppComponent = undefined;
     }
 
     this.pluginAppComponent = ReactDOM.render(
       <PluginApp
         PluginAPI={PluginAPI}
-        pluginId={context.pluginId}
+        pluginId={this.context.pluginId}
         definitions={definitions}
         initialLearnerState={initialLearnerState}
         askForUserDefinition={askForUserDefinition}
@@ -55,7 +87,7 @@ export class GlossaryPlugin {
       // It can be any other element in the document. Note that PluginApp render everything using React Portals.
       // It renders child components into external containers sent to LARA, not into context.div
       // or anything else that we provide here.
-      context.div);
+      this.context.div);
   }
 }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158302252

Authors will need to provide the following state in LARA:
```
{
  "url": "https://abc.concord.org/project-xyz/glossary.json"
}
```

I've added jest-fetch-mock so it's possible to test other network requests in the future (if there're any).