### PR TITLE
Let users display all their previous definitions

### DIFF
--- a/packages/glossary-plugin/src/components/definition.scss
+++ b/packages/glossary-plugin/src/components/definition.scss
@@ -1,22 +1,6 @@
-.userDefinitions {
-  margin-top: 20px;
-}
-
 .icons {
   display: inline-block;
-  margin-top: 6px;
   vertical-align: middle;
-}
-
-.iconButton {
-  font-size: 1.3em;
-  color: #999;
-  cursor: pointer;
-  margin-left: 10px;
-  margin-top: 3px;
-  &:hover {
-    color: #444;
-  }
 }
 
 .imageContainer {

--- a/packages/glossary-plugin/src/components/definition.test.tsx
+++ b/packages/glossary-plugin/src/components/definition.test.tsx
@@ -9,23 +9,9 @@ describe("Definition component", () => {
     const wrapper = shallow(
       <Definition
         definition={definition}
-        userDefinitions={[]}
       />
     );
     expect(wrapper.text()).toEqual(expect.stringContaining(definition));
-  });
-
-  it("renders the last user definitions if provided", () => {
-    const fistUserDefinition = "first user definition";
-    const lastUserDefinition = "last user definition";
-    const wrapper = shallow(
-      <Definition
-        definition="test definition"
-        userDefinitions={[ lastUserDefinition ]}
-      />
-    );
-    expect(wrapper.text()).not.toEqual(expect.stringContaining(fistUserDefinition));
-    expect(wrapper.text()).toEqual(expect.stringContaining(lastUserDefinition));
   });
 
   it("doesn't render text-to-speech icon if browser doesn't supports necessary API", () => {
@@ -35,7 +21,6 @@ describe("Definition component", () => {
     const wrapper = shallow(
       <Definition
         definition="test definition"
-        userDefinitions={[]}
       />
     );
     const icon = wrapper.find("." + icons.iconAudio);
@@ -52,7 +37,6 @@ describe("Definition component", () => {
     const wrapper = shallow(
       <Definition
         definition="test definition"
-        userDefinitions={[]}
       />
     );
 
@@ -69,7 +53,6 @@ describe("Definition component", () => {
     const wrapper = shallow(
       <Definition
         definition="test definition"
-        userDefinitions={[]}
         imageUrl={src}
         imageCaption={caption}
       />
@@ -88,7 +71,6 @@ describe("Definition component", () => {
     const wrapper = shallow(
       <Definition
         definition="test definition"
-        userDefinitions={[]}
         videoUrl={"http://test-video.mp4"}
         imageCaption={caption}
       />

--- a/packages/glossary-plugin/src/components/definition.tsx
+++ b/packages/glossary-plugin/src/components/definition.tsx
@@ -23,7 +23,7 @@ const textToSpeechAvailable = () => {
 export default class Definition extends React.Component<IProps, IState> {
   public state: IState = {
     imageVisible: false,
-    videoVisible: false,
+    videoVisible: false
   };
 
   public render() {

--- a/packages/glossary-plugin/src/components/definition.tsx
+++ b/packages/glossary-plugin/src/components/definition.tsx
@@ -4,7 +4,6 @@ import * as icons from "./icons.scss";
 
 interface IProps {
   definition: string;
-  userDefinitions?: string[];
   imageUrl?: string;
   videoUrl?: string;
   imageCaption?: string;
@@ -24,15 +23,12 @@ const textToSpeechAvailable = () => {
 export default class Definition extends React.Component<IProps, IState> {
   public state: IState = {
     imageVisible: false,
-    videoVisible: false
+    videoVisible: false,
   };
 
   public render() {
-    const { definition, userDefinitions, imageUrl, videoUrl, imageCaption, videoCaption } = this.props;
+    const { definition, imageUrl, videoUrl, imageCaption, videoCaption } = this.props;
     const { imageVisible, videoVisible } = this.state;
-    // The logic below is a bit scattered, but at least we don't have to repeat markup too much. And generally
-    // it's not a rocket science, so I wouldn't worry about it too much. The most important is to handle
-    // input and output (calling onUserDefinitionsUpdate) correctly as that's what the plugin code cares about.
     return (
       <div>
           <div>
@@ -40,10 +36,10 @@ export default class Definition extends React.Component<IProps, IState> {
             <span className={css.icons}>
               {
                 textToSpeechAvailable() &&
-                <span className={css.iconButton + " " + icons.iconAudio} onClick={this.readDefinition}/>
+                <span className={icons.iconButton + " " + icons.iconAudio} onClick={this.readDefinition}/>
               }
-              {imageUrl && <span className={css.iconButton + " " + icons.iconImage} onClick={this.toggleImage}/>}
-              {videoUrl && <span className={css.iconButton + " " + icons.iconVideo} onClick={this.toggleVideo}/>}
+              {imageUrl && <span className={icons.iconButton + " " + icons.iconImage} onClick={this.toggleImage}/>}
+              {videoUrl && <span className={icons.iconButton + " " + icons.iconVideo} onClick={this.toggleVideo}/>}
             </span>
           </div>
         {
@@ -58,17 +54,6 @@ export default class Definition extends React.Component<IProps, IState> {
           <div className={css.imageContainer}>
             <video src={videoUrl} controls={true}/>
             <div className={css.caption}>{videoCaption}</div>
-          </div>
-        }
-        {
-          // If user already provided some answer, display them below.
-          userDefinitions && userDefinitions.length > 0 &&
-          <div className={css.userDefinitions}>
-            <hr/>
-            <div>
-              <b>My definition:</b>
-            </div>
-            {userDefinitions[userDefinitions.length - 1]}
           </div>
         }
       </div>

--- a/packages/glossary-plugin/src/components/glossary-popup.scss
+++ b/packages/glossary-plugin/src/components/glossary-popup.scss
@@ -1,3 +1,7 @@
+.glossaryPopup {
+  font-size: 16px;
+}
+
 .userDefinitionTextarea {
   margin-top: 20px;
   padding: 5px;
@@ -27,6 +31,9 @@
   background: #aaa;
 }
 
-.userDefinitions {
+.userDefs {
   margin-top: 20px;
+  hr {
+    width: 90%;
+  }
 }

--- a/packages/glossary-plugin/src/components/glossary-popup.test.tsx
+++ b/packages/glossary-plugin/src/components/glossary-popup.test.tsx
@@ -70,12 +70,12 @@ describe("GlossaryPopup component", () => {
       it("renders user button allowing user to revise his answer", () => {
         const word = "test";
         const definition = "test def";
-        const userDef = "user definition";
+        const userDefinitions = ["user definition"];
         const wrapper = shallow(
           <GlossaryPopup
             word={word}
             definition={definition}
-            userDefinitions={[ userDef ]}
+            userDefinitions={userDefinitions}
             askForUserDefinition={true}
           />
         );
@@ -86,7 +86,8 @@ describe("GlossaryPopup component", () => {
         reviseButton.simulate("click");
         expect(wrapper.text()).toEqual(expect.stringContaining(`What do you think "${word}" means?`));
         expect(wrapper.find("textarea").length).toEqual(1);
-        expect(wrapper.text()).toEqual(expect.stringContaining(userDef));
+        // Finds a component with given properties (UserDefinitions)
+        expect(wrapper.find({userDefinitions}).length).toEqual(1);
       });
     });
   });

--- a/packages/glossary-plugin/src/components/glossary-popup.tsx
+++ b/packages/glossary-plugin/src/components/glossary-popup.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import Definition from "./definition";
+import UserDefinitions from "./user-definitions";
 import * as css from "./glossary-popup.scss";
 
 interface IProps {
@@ -29,28 +30,34 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
 
   public render() {
     const { questionVisible } = this.state;
-    return questionVisible ? this.renderQuestion() : this.renderDefinition();
+    return (
+      <div className={css.glossaryPopup}>
+        {questionVisible ? this.renderQuestion() : this.renderDefinition()}
+      </div>
+    );
   }
 
   private renderDefinition() {
     const { askForUserDefinition, definition, userDefinitions, imageUrl,
       videoUrl, imageCaption, videoCaption } = this.props;
-    const anyUserDef = userDefinitions && userDefinitions.length > 0;
     return (
       <div>
         <Definition
           definition={definition}
-          userDefinitions={askForUserDefinition ? userDefinitions : []}
           imageUrl={imageUrl}
           videoUrl={videoUrl}
           imageCaption={imageCaption}
           videoCaption={videoCaption}
         />
         {
-          askForUserDefinition && anyUserDef &&
-          <div className={css.buttons}>
-            <div className={css.button} data-cy="revise" onClick={this.handleRevise}>
-              Revise my definition
+          askForUserDefinition && userDefinitions && userDefinitions.length > 0 &&
+          <div className={css.userDefs}>
+            <hr />
+            <UserDefinitions userDefinitions={userDefinitions} />
+            <div className={css.buttons}>
+              <div className={css.button} data-cy="revise" onClick={this.handleRevise}>
+                Revise my definition
+              </div>
             </div>
           </div>
         }
@@ -74,11 +81,8 @@ export default class GlossaryPopup extends React.Component<IProps, IState> {
         {
           // If user already provided some answer, display them below.
           userDefinitions && userDefinitions.length > 0 &&
-          <div className={css.userDefinitions}>
-            <div>
-              <b>My previous definition:</b>
-            </div>
-            {userDefinitions[userDefinitions.length - 1]}
+          <div className={css.userDefs}>
+            <UserDefinitions userDefinitions={userDefinitions} />
           </div>
         }
         <div className={css.buttons}>

--- a/packages/glossary-plugin/src/components/glossary-sidebar.scss
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.scss
@@ -1,5 +1,13 @@
+.glossarySidebar {
+  font-size: 16px;
+}
+
 .entry {
   margin-bottom: 30px;
+}
+
+.userDefs {
+  margin-left: 20px;
 }
 
 .word {

--- a/packages/glossary-plugin/src/components/glossary-sidebar.tsx
+++ b/packages/glossary-plugin/src/components/glossary-sidebar.tsx
@@ -3,6 +3,7 @@ import Definition from "./definition";
 import { IWordDefinition, ILearnerDefinitions } from "./types";
 
 import * as css from "./glossary-sidebar.scss";
+import UserDefinitions from "./user-definitions";
 
 enum Filter {
   AllWords,
@@ -36,7 +37,7 @@ export default class GlossarySidebar extends React.Component<IProps, IState> {
       + (filter === Filter.WithUserDefinitionOnly ? " " + css.activeToggle : "");
     const allWordsClass = css.toggle + (filter === Filter.AllWords ? " " + css.activeToggle : "");
     return (
-      <div>
+      <div className={css.glossarySidebar}>
         {
           // Show toggles only if there's anything to toggle between.
           nonEmptyHash(learnerDefinitions) &&
@@ -64,12 +65,17 @@ export default class GlossarySidebar extends React.Component<IProps, IState> {
               <div className={css.definition}>
                 <Definition
                   definition={entry.definition}
-                  userDefinitions={learnerDefinitions[entry.word]}
                   imageUrl={entry.image}
                   videoUrl={entry.video}
                   imageCaption={entry.imageCaption}
                   videoCaption={entry.videoCaption}
                 />
+                {
+                  learnerDefinitions[entry.word] &&
+                  <div className={css.userDefs}>
+                    <UserDefinitions userDefinitions={learnerDefinitions[entry.word]} />
+                  </div>
+                }
               </div>
             </div>
           )

--- a/packages/glossary-plugin/src/components/icons.scss
+++ b/packages/glossary-plugin/src/components/icons.scss
@@ -31,33 +31,59 @@
   /* Better Font Rendering =========== */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  // Custom tweaks
+  display: inline-block;
+  vertical-align: middle;
+  transition: transform 0.5s;
 }
 
-.iconAudio:before {
-  @extend %icon;
-  content: "\e900";
+
+.iconButton {
+  font-size: 1.2em;
+  color: #999;
+  cursor: pointer;
+  margin-left: 10px;
+  &:hover {
+    color: #444;
+  }
 }
-.iconImage:before {
+
+.iconAudio {
   @extend %icon;
-  content: "\e901";
+  &:before {
+    content: "\e900";
+  }
 }
-.iconVideo:before {
+.iconImage {
   @extend %icon;
-  content: "\e902";
+  &:before {
+    content: "\e901";
+  }
 }
-.iconCaret:before {
+.iconVideo {
   @extend %icon;
-  content: "\e904";
+  &:before {
+    content: "\e902";
+  }
 }
-.iconBook:before {
+.iconCaret {
   @extend %icon;
-  content: "\e903";
+  &:before {
+    content: "\e904";
+  }
+  transform: rotate(0);
 }
-.iconRead:before {
+.iconCaretExpanded {
   @extend %icon;
-  content: "\e903";
+  &:before {
+    content: "\e904";
+  }
+  transform: rotate(90deg);
 }
-.iconReading:before {
+.iconBook {
   @extend %icon;
-  content: "\e903";
+  &:before {
+    content: "\e903";
+  }
 }

--- a/packages/glossary-plugin/src/components/user-definitions.scss
+++ b/packages/glossary-plugin/src/components/user-definitions.scss
@@ -1,0 +1,21 @@
+.userDefinitions {
+  margin-top: 15px;
+}
+
+.userDefinition {
+  margin-top: 5px;
+}
+
+.userDefinitionHeader {
+  font-weight: bold;
+  margin-top: 8px;
+}
+
+.remainingUserDefs {
+  transition: max-height 0.5s;
+  max-height: 0;
+  &.expanded {
+    max-height: 1000px;
+    overflow: auto;
+  }
+}

--- a/packages/glossary-plugin/src/components/user-definitions.test.tsx
+++ b/packages/glossary-plugin/src/components/user-definitions.test.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import UserDefinitions from "./user-definitions";
+import * as icons from "./icons.scss";
+import { shallow } from "enzyme";
+
+describe("UserDefinitions component", () => {
+  describe("when there's only one user definition available", () => {
+    const userDefinition = "first user definition";
+    const userDefinitions = [ userDefinition ];
+
+    it("renders the this definition without expand button", () => {
+      const wrapper = shallow(
+        <UserDefinitions
+          userDefinitions={userDefinitions}
+        />
+      );
+      expect(wrapper.text()).toEqual(expect.stringContaining(userDefinition));
+      const icon = wrapper.find("." + icons.iconCaret);
+      expect(icon.length).toEqual(0);
+    });
+  });
+
+  describe("when there are multiple user definitions available", () => {
+    const fistUserDefinition = "first user definition";
+    const lastUserDefinition = "last user definition";
+    const userDefinitions = [ fistUserDefinition, "2 def", "3 def", "4 def", lastUserDefinition ];
+
+    it("renders the last user definition", () => {
+      const wrapper = shallow(
+        <UserDefinitions
+          userDefinitions={userDefinitions}
+        />
+      );
+      expect(wrapper.text()).not.toEqual(expect.stringContaining(fistUserDefinition));
+      expect(wrapper.text()).toEqual(expect.stringContaining(lastUserDefinition));
+    });
+
+    it("renders renders expand icon if there are multiple definitions", () => {
+      const wrapper = shallow(
+        <UserDefinitions
+          userDefinitions={userDefinitions}
+        />
+      );
+      const icon = wrapper.find("." + icons.iconCaret);
+      expect(icon.length).toEqual(1);
+      icon.simulate("click");
+      expect(wrapper.text()).toEqual(expect.stringContaining(fistUserDefinition));
+      expect(wrapper.text()).toEqual(expect.stringContaining(lastUserDefinition));
+    });
+
+    it("renders previous user definitions using correct ordinals", () => {
+      const wrapper = shallow(
+        <UserDefinitions
+          userDefinitions={userDefinitions}
+        />
+      );
+      const icon = wrapper.find("." + icons.iconCaret);
+      expect(icon.length).toEqual(1);
+      icon.simulate("click");
+      expect(wrapper.text()).toEqual(expect.stringContaining("My  definition"));
+      expect(wrapper.text()).toEqual(expect.stringContaining("My previous definition"));
+      expect(wrapper.text()).toEqual(expect.stringContaining("My 3rd definition"));
+      expect(wrapper.text()).toEqual(expect.stringContaining("My 2nd definition"));
+      expect(wrapper.text()).toEqual(expect.stringContaining("My 1st definition"));
+    });
+  });
+});

--- a/packages/glossary-plugin/src/components/user-definitions.tsx
+++ b/packages/glossary-plugin/src/components/user-definitions.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import * as css from "./user-definitions.scss";
+import * as icons from "./icons.scss";
+
+interface IProps {
+  userDefinitions: string[];
+}
+
+interface IState {
+  allUserDefsVisible: boolean;
+}
+
+const getOrdinal = (n: number, max: number) => {
+  if (n === 0) {
+    return ""; // current
+  }
+  if (n === 1) {
+    return "previous";
+  }
+  n = max - n;
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+};
+
+export default class UserDefinitions extends React.Component<IProps, IState> {
+  public state: IState = {
+    allUserDefsVisible: false
+  };
+
+  public render() {
+    const { userDefinitions, } = this.props;
+    const { allUserDefsVisible } = this.state;
+    if (userDefinitions.length === 0) {
+      return null;
+    }
+    const caretIconClass = icons.iconButton + " " + (allUserDefsVisible ? icons.iconCaretExpanded : icons.iconCaret);
+    return (
+      <div className={css.userDefinitions}>
+        {this.renderUserDef(0)}
+        {
+          userDefinitions.length > 1 &&
+          <span className={caretIconClass} onClick={this.toggleAllUserDefinitions}/>
+        }
+        <div className={css.remainingUserDefs + " " + (allUserDefsVisible ? css.expanded : "")}>
+          {allUserDefsVisible &&
+            // .slice(1).map is just a way to iterate over userDefinitions.length - 2 numbers, as the first one
+            // is already rendered above. Note that we ignore values.
+            userDefinitions.slice(1).map((_, index) => this.renderUserDef(index + 1))
+          }
+        </div>
+      </div>
+    );
+  }
+
+  // Note that index = 0 means the most recent definition (current one).
+  private renderUserDef(index: number) {
+    const { userDefinitions } = this.props;
+    if (!userDefinitions) {
+      return;
+    }
+    return (
+      <span className={css.userDefinition} key={index}>
+        <div className={css.userDefinitionHeader}>
+          My {getOrdinal(index, userDefinitions.length)} definition:
+        </div>
+        {userDefinitions[userDefinitions.length - 1 - index]}
+      </span>
+    );
+  }
+
+  private toggleAllUserDefinitions = () => {
+    const { allUserDefsVisible } = this.state;
+    this.setState({
+      allUserDefsVisible: !allUserDefsVisible,
+    });
+  }
+}

--- a/packages/glossary-plugin/src/demo.tsx
+++ b/packages/glossary-plugin/src/demo.tsx
@@ -30,7 +30,7 @@ ReactDOM.render(
     imageUrl={img}
     videoUrl={video}
     videoCaption="Source: Wikimedia. This video is unrelated to an eardrum. This is a test caption."
-    userDefinitions={["I don't know"]}
+    userDefinitions={["I don't know", "Still not sure", "Something in the ear", "A membrane"]}
     askForUserDefinition={true}
     onUserDefinitionsUpdate={newUserDefinition}
   />,
@@ -53,7 +53,7 @@ ReactDOM.render(
         definition: "A visible mass of condensed watery vapour floating in the atmosphere.",
       }
     ]}
-    learnerDefinitions={{cloud: ["white fluffy thing"]}}
+    learnerDefinitions={{cloud: ["I don't know", "Still not sure", "Something in the air", "White fluffy thing"]}}
   />,
   document.getElementById("sidebar") as HTMLElement
 );


### PR DESCRIPTION
[#160456009]

The same UI is used in Popup and Sidebar components. I've divided Definition into Definition and UserDefinitions, as there is a bit different styling used in popup and sidebar. When components are separate, it's easier to achieve that.